### PR TITLE
Typo: messageRecieved -> messageReceived 

### DIFF
--- a/src/qamqp/amqp_queue.cpp
+++ b/src/qamqp/amqp_queue.cpp
@@ -562,6 +562,6 @@ void QueuePrivate::_q_body( int channeNumber, const QByteArray & body )
 	
 	if(message->leftSize == 0 && messages_.size() == 1)
 	{
-		QMetaObject::invokeMethod(pq_func(), "messageRecieved");
+		QMetaObject::invokeMethod(pq_func(), "messageReceived");
 	}
 }

--- a/src/qamqp/amqp_queue.h
+++ b/src/qamqp/amqp_queue.h
@@ -77,7 +77,7 @@ namespace QAMQP
 		void declared();
 		void binded(bool);
 		void removed();
-		void messageRecieved();
+		void messageReceived();
 		void empty();
 
 	private:

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -21,8 +21,8 @@ Test::Test()
 
 	connect(queue2_, SIGNAL(declared()), this, SLOT(declared()));
 
-	connect(queue_, SIGNAL(messageRecieved()), this, SLOT(newMessage()));	
-	connect(queue2_, SIGNAL(messageRecieved()), this, SLOT(newMessage()));
+	connect(queue_, SIGNAL(messageReceived()), this, SLOT(newMessage()));	
+	connect(queue2_, SIGNAL(messageReceived()), this, SLOT(newMessage()));
 }
 
 Test::~Test()


### PR DESCRIPTION
The Queue signal "Message Received" has a typo...

For backward compatibility, it should maybe keep both signals for some time.
