### PR TITLE
AMQP vhost should not contain leading / from URL path

### DIFF
--- a/src/qamqp/amqp.cpp
+++ b/src/qamqp/amqp.cpp
@@ -112,8 +112,15 @@ void ClientPrivate::parseCnnString( const QUrl & con )
 		q->setPassword(con.password());
 		q->setUser(con.userName());
 		q->setPort(con.port(AMQPPORT));
-		q->setHost(con.host());				
-		q->setVirtualHost(con.path());
+		q->setHost(con.host());
+                QString path = con.path();
+                // Path from URL always contains leading / and cannot
+                // be used as vhost name. Accoring to AMQP URI spec,
+                // leading / is not part of vhost name, for details see:
+                // http://www.rabbitmq.com/uri-spec.html
+                if (path.startsWith("/"))
+                    path.remove(0, 1);
+		q->setVirtualHost(path);
 	}
 }
 


### PR DESCRIPTION
According to AMQP URI spec, vhost name does not include the leading / as normally present in URI path.
This, leading / has to be stripped from the path in order to be use as a vhost. For details see: http://www.rabbitmq.com/uri-spec.html

Signed-off-by: Maciej Borzecki maciej.borzecki@open-rnd.pl
Signed-off-by: Maciej Borzecki maciek.borzecki@gmail.com
